### PR TITLE
Better status reporting when polling job/report

### DIFF
--- a/src/lib/components/BlastWorkspaceResult.tsx
+++ b/src/lib/components/BlastWorkspaceResult.tsx
@@ -179,6 +179,7 @@ export function BlastWorkspaceResult(props: Props) {
   ) : queryResultState == null ||
     jobResultState.status === 'job-running' ||
     reportResultState == null ||
+    reportResultState.status === 'report-running' ||
     individualQueriesResult.value == null ? (
     <LoadingBlastResult {...props} />
   ) : (

--- a/src/lib/components/BlastWorkspaceResult.tsx
+++ b/src/lib/components/BlastWorkspaceResult.tsx
@@ -96,11 +96,19 @@ export function BlastWorkspaceResult(props: Props) {
     [blastApi, jobResultState]
   );
 
-  const multiQueryReportResult = usePromise(
-    async () =>
-      reportResultState?.status !== 'report-completed'
-        ? undefined
-        : blastApi.fetchSingleFileJsonReport(reportResultState.report.reportID),
+  const [multiQueryReportState, setMultiQueryReportState] = useState<
+    ApiResult<MultiQueryReportJson, ErrorDetails>
+  >();
+
+  useEffect(
+    () =>
+      Task.fromPromise(async () =>
+        reportResultState?.status !== 'report-completed'
+          ? undefined
+          : blastApi.fetchSingleFileJsonReport(
+              reportResultState.report.reportID
+            )
+      ).run(setMultiQueryReportState),
     [blastApi, reportResultState]
   );
 
@@ -179,7 +187,7 @@ export function BlastWorkspaceResult(props: Props) {
       individualQueries={individualQueriesResult.value.value}
       jobDetails={jobResultState.job}
       query={queryResultState.value}
-      multiQueryReportResult={multiQueryReportResult}
+      multiQueryReportResult={multiQueryReportState}
     />
   );
 }
@@ -209,10 +217,9 @@ function LoadingBlastResult(props: Props) {
   );
 }
 
-export interface MultiQueryReportResult {
-  value?: ApiResult<MultiQueryReportJson, ErrorDetails>;
-  loading: boolean;
-}
+export type MultiQueryReportResult =
+  | ApiResult<MultiQueryReportJson, ErrorDetails>
+  | undefined;
 
 interface CompleteBlastResultProps extends Props {
   individualQueries: IndividualQuery[];

--- a/src/lib/components/BlastWorkspaceResult.tsx
+++ b/src/lib/components/BlastWorkspaceResult.tsx
@@ -510,7 +510,7 @@ async function makeJobPollingPromise(
   }
 }
 
-type ReportPollingState =
+export type ReportPollingState =
   | ReportPollingInProgress
   | ReportPollingSuccess
   | ReportPollingError;

--- a/src/lib/components/ReportSelect.tsx
+++ b/src/lib/components/ReportSelect.tsx
@@ -103,7 +103,8 @@ export function ReportSelect({
   useEffect(() => {
     if (
       selectedReportOption == null ||
-      selectedReportOption.value === 'combined-result-table'
+      selectedReportOption.value === 'combined-result-table' ||
+      (reportState != null && reportState.status !== 'report-running')
     ) {
       return;
     }
@@ -113,7 +114,7 @@ export function ReportSelect({
     return Task.fromPromise(() =>
       makeReportPollingPromise(blastApi, jobId, format)
     ).run(setReportState);
-  }, [blastApi, jobId, selectedReportOption]);
+  }, [blastApi, jobId, selectedReportOption, reportState]);
 
   useEffect(() => {
     if (

--- a/src/lib/components/ReportSelect.tsx
+++ b/src/lib/components/ReportSelect.tsx
@@ -91,6 +91,11 @@ export function ReportSelect({
     jobId,
   });
 
+  const resetSelectedReport = useCallback(() => {
+    setSelectedReportOption(undefined);
+    setReportState({ status: 'report-pending', jobId });
+  }, [jobId]);
+
   const onChangeReport = useCallback(
     (
       option: ValueType<ReportOption, false>,
@@ -138,17 +143,15 @@ export function ReportSelect({
         shouldZip,
         `${jobId}-${format}-report`
       )
-    ).run(
-      () => {
-        setSelectedReportOption(undefined);
-        setReportState({ status: 'report-pending', jobId });
-      },
-      () => {
-        setSelectedReportOption(undefined);
-        setReportState({ status: 'report-pending', jobId });
-      }
-    );
-  }, [blastServiceUrl, wdkService, reportState, jobId, selectedReportOption]);
+    ).run(resetSelectedReport, resetSelectedReport);
+  }, [
+    blastServiceUrl,
+    wdkService,
+    resetSelectedReport,
+    reportState,
+    jobId,
+    selectedReportOption,
+  ]);
 
   useEffect(() => {
     if (
@@ -160,17 +163,13 @@ export function ReportSelect({
 
     return Task.fromPromise(async () =>
       combinedResultTableDownloadConfig.onClickDownloadTable()
-    ).run(
-      () => {
-        setSelectedReportOption(undefined);
-        setReportState({ status: 'report-pending', jobId });
-      },
-      () => {
-        setSelectedReportOption(undefined);
-        setReportState({ status: 'report-pending', jobId });
-      }
-    );
-  }, [jobId, combinedResultTableDownloadConfig, selectedReportOption]);
+    ).run(resetSelectedReport, resetSelectedReport);
+  }, [
+    resetSelectedReport,
+    jobId,
+    combinedResultTableDownloadConfig,
+    selectedReportOption,
+  ]);
 
   const options = useMemo(
     () =>

--- a/src/lib/components/ReportSelect.tsx
+++ b/src/lib/components/ReportSelect.tsx
@@ -4,6 +4,7 @@ import Select, { ActionMeta, OptionsType, ValueType } from 'react-select';
 
 import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
 import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
+import { Task } from '@veupathdb/wdk-client/lib/Utils/Task';
 
 import { Props as CombinedResultProps } from '../components/CombinedResult';
 import { BlastServiceUrl, useBlastApi } from '../hooks/api';
@@ -93,12 +94,10 @@ export function ReportSelect({
     []
   );
 
-  useEffect(() => {
-    let canceled = false;
-
-    (async () => {
-      if (selectedReportOption != null) {
-        try {
+  useEffect(
+    () =>
+      Task.fromPromise(async () => {
+        if (selectedReportOption != null) {
           if (selectedReportOption.value === 'combined-result-table') {
             if (combinedResultTableDownloadConfig?.offer) {
               await combinedResultTableDownloadConfig.onClickDownloadTable();
@@ -116,25 +115,20 @@ export function ReportSelect({
               `${jobId}-${format}-report`
             );
           }
-        } finally {
-          if (!canceled) {
-            setSelectedReportOption(undefined);
-          }
         }
-      }
-    })();
-
-    return () => {
-      canceled = true;
-    };
-  }, [
-    blastApi,
-    blastServiceUrl,
-    wdkService,
-    combinedResultTableDownloadConfig,
-    jobId,
-    selectedReportOption,
-  ]);
+      }).run(
+        () => setSelectedReportOption(undefined),
+        () => setSelectedReportOption(undefined)
+      ),
+    [
+      blastApi,
+      blastServiceUrl,
+      wdkService,
+      combinedResultTableDownloadConfig,
+      jobId,
+      selectedReportOption,
+    ]
+  );
 
   const options = useMemo(
     () =>

--- a/src/lib/components/ReportSelect.tsx
+++ b/src/lib/components/ReportSelect.tsx
@@ -86,7 +86,10 @@ export function ReportSelect({
   const [selectedReportOption, setSelectedReportOption] = useState<
     ReportOption | undefined
   >(undefined);
-  const [reportState, setReportState] = useState<ReportPollingState>();
+  const [reportState, setReportState] = useState<ReportPollingState>({
+    status: 'report-pending',
+    jobId,
+  });
 
   const onChangeReport = useCallback(
     (
@@ -104,7 +107,7 @@ export function ReportSelect({
     if (
       selectedReportOption == null ||
       selectedReportOption.value === 'combined-result-table' ||
-      (reportState != null && reportState.status !== 'report-running')
+      (reportState.status !== 'report-pending' && reportState.jobId === jobId)
     ) {
       return;
     }
@@ -120,8 +123,7 @@ export function ReportSelect({
     if (
       selectedReportOption == null ||
       selectedReportOption.value === 'combined-result-table' ||
-      reportState == null ||
-      reportState.status === 'report-running'
+      reportState.status === 'report-pending'
     ) {
       return;
     }
@@ -139,11 +141,11 @@ export function ReportSelect({
     ).run(
       () => {
         setSelectedReportOption(undefined);
-        setReportState(undefined);
+        setReportState({ status: 'report-pending', jobId });
       },
       () => {
         setSelectedReportOption(undefined);
-        setReportState(undefined);
+        setReportState({ status: 'report-pending', jobId });
       }
     );
   }, [blastServiceUrl, wdkService, reportState, jobId, selectedReportOption]);
@@ -161,14 +163,14 @@ export function ReportSelect({
     ).run(
       () => {
         setSelectedReportOption(undefined);
-        setReportState(undefined);
+        setReportState({ status: 'report-pending', jobId });
       },
       () => {
         setSelectedReportOption(undefined);
-        setReportState(undefined);
+        setReportState({ status: 'report-pending', jobId });
       }
     );
-  }, [combinedResultTableDownloadConfig, selectedReportOption]);
+  }, [jobId, combinedResultTableDownloadConfig, selectedReportOption]);
 
   const options = useMemo(
     () =>

--- a/src/lib/components/ResultContainer.tsx
+++ b/src/lib/components/ResultContainer.tsx
@@ -40,9 +40,9 @@ export function ResultContainer(props: Props) {
   const individualResultProps = useIndividualResultProps({
     ...props,
     combinedResult:
-      props.multiQueryReportResult?.value?.status !== 'ok'
+      props.multiQueryReportResult?.status !== 'ok'
         ? undefined
-        : props.multiQueryReportResult.value.value,
+        : props.multiQueryReportResult.value,
   });
 
   return (
@@ -67,7 +67,7 @@ function CombinedResultContainer(
   }
 ) {
   return props.multiQueryReportResult == null ||
-    props.multiQueryReportResult.value == null ||
+    props.multiQueryReportResult == null ||
     props.projectUrls == null ||
     props.organismToProject == null ? (
     <Loading>
@@ -76,7 +76,7 @@ function CombinedResultContainer(
   ) : (
     <LoadedCombinedResultContainer
       {...props}
-      combinedResult={props.multiQueryReportResult.value}
+      combinedResult={props.multiQueryReportResult}
       organismToProject={props.organismToProject}
       projectUrls={props.projectUrls}
     />

--- a/src/lib/hooks/api.ts
+++ b/src/lib/hooks/api.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext } from 'react';
 
 import { Dispatch } from 'redux';
 import { useDispatch } from 'react-redux';
@@ -8,16 +8,14 @@ import { once } from 'lodash';
 import { notifyUnhandledError } from '@veupathdb/wdk-client/lib/Actions/UnhandledErrorActions';
 import { WdkDependenciesContext } from '@veupathdb/wdk-client/lib/Hooks/WdkDependenciesEffect';
 import { useNonNullableContext } from '@veupathdb/wdk-client/lib/Hooks/NonNullableContext';
-import { useWdkService } from '@veupathdb/wdk-client/lib/Hooks/WdkServiceHook';
 
-import { IoBlastFormat } from '../utils/ServiceTypes';
-import { BlastApi, createJobContentDownloader } from '../utils/api';
+import { BlastApi } from '../utils/api';
 import {
   BlastCompatibleWdkService,
   isBlastCompatibleWdkService,
 } from '../utils/wdkServiceIntegration';
 
-const BlastServiceUrl = createContext('/multi-blast');
+export const BlastServiceUrl = createContext('/multi-blast');
 
 export function useBlastApi() {
   const blastServiceUrl = useContext(BlastServiceUrl);
@@ -51,24 +49,3 @@ const makeErrorReporter = once(function (
     dispatch(notifyUnhandledError(error));
   };
 });
-
-export function useDownloadReportCallback(jobId: string) {
-  const blastServiceUrl = useContext(BlastServiceUrl);
-
-  const user = useWdkService((wdkService) => wdkService.getCurrentUser(), []);
-
-  const blastApi = useBlastApi();
-
-  return useMemo(() => {
-    const reportDownloader =
-      user &&
-      blastApi &&
-      createJobContentDownloader(user, blastApi, blastServiceUrl, jobId);
-
-    return (
-      reportDownloader &&
-      ((jobId: string, format: IoBlastFormat, zip: boolean) =>
-        reportDownloader(format, zip, `${jobId}-${format}-report`))
-    );
-  }, [user, blastApi, blastServiceUrl, jobId]);
-}

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -271,7 +271,7 @@ export async function downloadJobContent(
   shouldZip: boolean,
   filename: string
 ): Promise<void> {
-  if (reportResponse.status === 'report-running') {
+  if (reportResponse.status === 'report-pending') {
     throw new Error('Tried to download a report which has not yet finished.');
   }
 

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -244,6 +244,14 @@ export class BlastApi extends FetchClientWithCredentials {
       transformResponse: ioTransformer(string),
     });
   }
+
+  fetchJobQueueError(jobId: string) {
+    return this.taggedFetch({
+      path: `${JOBS_PATH}/${jobId}/error`,
+      method: 'GET',
+      transformResponse: ioTransformer(string),
+    });
+  }
 }
 
 function transformTooLargeError(errorDetails: ErrorDetails): ErrorDetails {

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -13,13 +13,12 @@ import {
 
 import { User } from '@veupathdb/wdk-client/lib/Utils/WdkUser';
 
-import { makeReportPollingPromise } from '../components/BlastWorkspaceResult';
+import { ReportPollingState } from '../components/BlastWorkspaceResult';
 
 import {
   ApiResult,
   ErrorDetails,
   IoBlastConfig,
-  IoBlastFormat,
   ReportConfig,
   createJobResponse,
   createReportResponse,
@@ -266,20 +265,12 @@ function transformTooLargeError(errorDetails: ErrorDetails): ErrorDetails {
 // FIXME: Update FetchClientWithCredentials to accommodate responses
 // with "attachment" Content-Disposition
 export async function downloadJobContent(
-  blastApi: BlastApi,
   blastServiceUrl: string,
   user: User,
-  jobId: string,
-  format: IoBlastFormat,
+  reportResponse: ReportPollingState,
   shouldZip: boolean,
   filename: string
 ): Promise<void> {
-  const reportResponse = await makeReportPollingPromise(
-    blastApi,
-    jobId,
-    format
-  );
-
   if (reportResponse.status === 'report-running') {
     throw new Error('Tried to download a report which has not yet finished.');
   }

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -275,12 +275,16 @@ export function createJobContentDownloader(
     format: IoBlastFormat,
     shouldZip: boolean,
     filename: string
-  ) {
+  ): Promise<void> {
     const reportResponse = await makeReportPollingPromise(
       blastApi,
       jobId,
       format
     );
+
+    if (reportResponse.status === 'report-running') {
+      return downloadJobContent(format, shouldZip, filename);
+    }
 
     if (reportResponse.status === 'queueing-error') {
       throw new Error('We were unable to queue your report.');


### PR DESCRIPTION
Resolves #7
Resolves #17

This PR:
1. Improves the error reporting when a service error precludes a newly-created BLAST job from being enqueued and run. When such a queueing error occurs, the client will query a dedicated endpoint which serves error details, and display the details on the error page.
2. Stops the polling of the relevant BLAST and report jobs if the component which triggered the polling is unmounted (e.g., when the user navigates away from the result page). This is accomplished by refactoring `makeJobPollingPromise` and `makeReportPollingPromise` to resolve to the state of the job after ONE step of polling is performed. (The original implementation would return a promise which does not resolve until the job has reached an "errored" or "completed" state.) This refactoring allows polling to be canceled if the triggering component is unmounted before the job is "errored" or "completed."